### PR TITLE
⚡️ Improve load time for public-liked-songs

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -7,7 +7,7 @@
 		"dev": "yarn build && firebase emulators:start --only functions,firestore,pubsub --inspect-functions -P dev",
 		"shell-prep": "yarn build && firebase emulators:start --only firestore,pubsub -P dev",
 		"shell": "yarn build && firebase functions:shell -P dev --inspect-functions",
-		"test": "jest",
+		"test": "jest --silent",
 		"deploy": "firebase deploy --only functions -P prod",
 		"logs": "firebase functions:log"
 	},

--- a/functions/src/spotify/index.ts
+++ b/functions/src/spotify/index.ts
@@ -61,10 +61,12 @@ export default class Spotify {
 		)
 	}
 
-	private async getAll<T>(endpoint: string): Promise<T[]> {
+	private async getAll<T>(endpoint: string, params?: Record<string, Primative>): Promise<T[]> {
 		const limit = 50
 		const { items, total } = await this.request<SpotifyApi.PagingObject<T>>(endpoint, 'GET', {
-			limit
+			limit,
+			fields: 'items,total',
+			...params
 		})
 		const reqN = [...Array(Math.ceil(total / limit)).keys()] // number of request that need to be run
 		reqN.shift() // first request has already been run
@@ -72,7 +74,9 @@ export default class Spotify {
 			reqN.map(i =>
 				this.request<SpotifyApi.PagingObject<T>>(endpoint, 'GET', {
 					limit,
-					offset: limit * i
+					offset: limit * i,
+					fields: 'items',
+					...params
 				})
 			)
 		)
@@ -128,7 +132,10 @@ export default class Spotify {
 	}
 
 	getPlaylistTracks(playlistId: string) {
-		return this.getAll<SpotifyApi.PlaylistTrackObject>(`playlists/${playlistId}/tracks`)
+		type SimplifiedPlaylistTrack = { track: { uri: string } | null }
+		return this.getAll<SimplifiedPlaylistTrack>(`playlists/${playlistId}/tracks`, {
+			fields: 'items.track.uri,total'
+		})
 	}
 
 	addTracksToPlaylist(playlistId: string, uris: string[]) {

--- a/functions/src/spotify/index.ts
+++ b/functions/src/spotify/index.ts
@@ -61,7 +61,7 @@ export default class Spotify {
 		)
 	}
 
-	private async requestAll<T>(endpoint: string): Promise<T[]> {
+	private async getAll<T>(endpoint: string): Promise<T[]> {
 		const limit = 50
 		const { items, total } = await this.request<SpotifyApi.PagingObject<T>>(endpoint, 'GET', {
 			limit
@@ -108,11 +108,11 @@ export default class Spotify {
 	}
 
 	getMySavedTracks() {
-		return this.requestAll<SpotifyApi.SavedTrackObject>('me/tracks')
+		return this.getAll<SpotifyApi.SavedTrackObject>('me/tracks')
 	}
 
 	getMyPlaylists() {
-		return this.requestAll<SpotifyApi.PlaylistObjectSimplified>('me/playlists')
+		return this.getAll<SpotifyApi.PlaylistObjectSimplified>('me/playlists')
 	}
 
 	createPlaylist(userId: string, details: PlaylistDetails) {
@@ -128,7 +128,7 @@ export default class Spotify {
 	}
 
 	getPlaylistTracks(playlistId: string) {
-		return this.requestAll<SpotifyApi.PlaylistTrackObject>(`playlists/${playlistId}/tracks`)
+		return this.getAll<SpotifyApi.PlaylistTrackObject>(`playlists/${playlistId}/tracks`)
 	}
 
 	addTracksToPlaylist(playlistId: string, uris: string[]) {

--- a/functions/src/tools/index.ts
+++ b/functions/src/tools/index.ts
@@ -1,1 +1,3 @@
+export type { CallableFunction } from 'firebase-functions/v2/https'
+
 export * as publicLikedSongs from './public-liked-songs'

--- a/functions/src/tools/public-liked-songs.ts
+++ b/functions/src/tools/public-liked-songs.ts
@@ -115,8 +115,15 @@ export const populate = onCall<PopulateParams>({ secrets }, async ({ data, auth 
 		clientSecret: process.env.SPOTIFY_CLIENT_SECRET,
 		refreshToken: docData.refresh_token
 	})
+	await spotify.refreshAccessToken().catch(err => {
+		if (err instanceof Error && err.message.includes('invalid_grant')) {
+			warn('Unable to get Spotify refresh token.', { tool, error: err })
+			throw new HttpsError('unauthenticated', 'Spotify authorization denied')
+		}
+		throw err
+	})
+
 	try {
-		await spotify.refreshAccessToken()
 		return await update(spotify, docData.playlist_id)
 	} catch (err) {
 		const msg = 'Failed to populate playlist.'

--- a/functions/src/tools/public-liked-songs.ts
+++ b/functions/src/tools/public-liked-songs.ts
@@ -8,13 +8,18 @@ import { secrets } from '../env'
 
 const tool = 'public-liked-songs'
 
-interface Document {
+type Document = {
 	refresh_token: string
 	playlist_id?: string
 	uid: string
 }
 
-export const create = onCall<Data>({ secrets }, async ({ data, auth }) => {
+type CreateParams = {
+	code: string
+	origin: string
+}
+
+export const create = onCall<CreateParams>({ secrets }, async ({ data, auth }) => {
 	if (!auth) throw new HttpsError('unauthenticated', 'User must be authenticated.')
 
 	const spotify = new Spotify({
@@ -85,11 +90,6 @@ export const create = onCall<Data>({ secrets }, async ({ data, auth }) => {
 		throw new HttpsError('unknown', msg, err)
 	}
 })
-
-interface Data {
-	code: string
-	origin: string
-}
 
 export const sync = onSchedule({ schedule: '0 0 * * *', secrets }, async () => {
 	const docRefs = await db.collection(tool).listDocuments()

--- a/functions/src/tools/public-liked-songs.ts
+++ b/functions/src/tools/public-liked-songs.ts
@@ -31,7 +31,7 @@ export const create = onCall<Data>({ secrets }, async ({ data, auth }) => {
 	})
 	const user = await spotify.getMe()
 
-	const ref = db.collection('public-liked-songs').doc(user.id)
+	const ref = db.collection(tool).doc(user.id)
 	let doc = await ref.get()
 
 	let docData: Document
@@ -92,7 +92,7 @@ interface Data {
 }
 
 export const sync = onSchedule({ schedule: '0 0 * * *', secrets }, async () => {
-	const docRefs = await db.collection('public-liked-songs').listDocuments()
+	const docRefs = await db.collection(tool).listDocuments()
 	const jobs = await Promise.allSettled(
 		docRefs.map(async ref => {
 			const doc = await ref.get()

--- a/functions/src/tools/public-liked-songs.ts
+++ b/functions/src/tools/public-liked-songs.ts
@@ -105,8 +105,7 @@ export const sync = onSchedule({ schedule: '0 0 * * *', secrets }, async () => {
 			try {
 				await spotify.refreshAccessToken()
 				if (data.playlist_id) {
-					const user = await spotify.getMe()
-					if (!(await spotify.usersFollowPlaylist(data.playlist_id, [user.id]))[0])
+					if (!(await spotify.usersFollowPlaylist(data.playlist_id, [doc.id]))[0])
 						return await ref.delete()
 					else return await update(spotify, data.playlist_id)
 				} else return await ref.delete()

--- a/functions/tests/spotify-mocked.ts
+++ b/functions/tests/spotify-mocked.ts
@@ -52,9 +52,7 @@ ms.createPlaylist.mockImplementation(async () => fullPlaylist)
 
 ms.changePlaylistDetails.mockImplementation(() => Promise.resolve())
 
-const playlistTracks = savedTrack as SpotifyApi.PlaylistTrackObject
-
-ms.getPlaylistTracks.mockImplementation(async () => [playlistTracks])
+ms.getPlaylistTracks.mockImplementation(async () => [{ track }])
 
 const playlistSnapshot: SpotifyApi.PlaylistSnapshotResponse = { snapshot_id: 'snapshotId' }
 

--- a/functions/tests/spotify.test.ts
+++ b/functions/tests/spotify.test.ts
@@ -1,7 +1,7 @@
 /** @jest-environment node */
 import Spotify from 'src/spotify'
 
-test(Spotify.prototype['requestAll'].name, async () => {
+test(Spotify.prototype['getAll'].name, async () => {
 	type Spy = jest.SpiedFunction<Spotify['request']>
 	const spy = jest.spyOn(Spotify.prototype, 'request' as keyof Spotify) as unknown as Spy
 	const spotify = new Spotify({})

--- a/functions/tests/tools/public-liked-songs.test.ts
+++ b/functions/tests/tools/public-liked-songs.test.ts
@@ -1,70 +1,28 @@
 import ms from '../spotify-mocked'
-import { create, sync } from 'src/tools/public-liked-songs'
+import { create, sync, populate } from 'src/tools/public-liked-songs'
 import { db } from 'src/init'
 import { HttpsError, CallableRequest, CallableFunction } from 'firebase-functions/v2/https'
-
-const doc = db.doc('public-liked-songs/userId')
-const scheduleTime = new Date().toISOString()
 
 afterEach(async () => {
 	if ((await doc.get()).exists) await doc.delete()
 	jest.clearAllMocks()
 })
 
-describe('update', () => {
-	beforeEach(async () => {
-		await doc.create({ refresh_token: 'userId', playlist_id: 'playlistId' })
-	})
-	function toTracks<T>(uris: string[]): T[] {
-		return uris.map(uri => ({ track: { uri } } as T))
-	}
-	function getUris(calls: [string, string[]][]) {
-		return calls.flatMap(([, uris]) => uris)
-	}
+type Data<F> = F extends CallableFunction<infer T, unknown> ? T : never
+const doc = db.doc('public-liked-songs/userId')
+const scheduleTime = new Date().toISOString()
+const rawRequest = {} as CallableRequest<unknown>['rawRequest']
+type Auth = NonNullable<CallableRequest<unknown>['auth']>
+const auth: Auth = {
+	uid: testEnv.auth.exampleUserRecord().uid,
+	token: {} as Auth['token']
+}
+const refresh_token = 'refreshToken'
+const playlist_id = 'playlistId'
+const origin = 'http://localhost:5050'
 
-	test('update synced playlist', async () => {
-		const savedTrackUris = ['uri1', 'uri3', 'uri4', 'uri5']
-		const playlistTrackUris = ['uri2', 'uri4', 'uri6', 'uri7']
-		ms.getMySavedTracks.mockImplementationOnce(async () =>
-			toTracks<SpotifyApi.SavedTrackObject>(savedTrackUris)
-		)
-		ms.getPlaylistTracks.mockImplementationOnce(async () =>
-			toTracks<SpotifyApi.PlaylistTrackObject>(playlistTrackUris)
-		)
-		await sync.run({ scheduleTime })
-		const added = getUris(ms.addTracksToPlaylist.mock.calls)
-		const removed = getUris(ms.removeTracksToPlaylist.mock.calls)
-		expect(added.reverse()).toEqual(['uri1', 'uri3', 'uri5'])
-		expect(removed.sort()).toEqual(['uri2', 'uri6', 'uri7'])
-	})
-
-	test('Update are made in order', async () => {
-		const savedTrackUris = Array.from(Array(103).keys()).map(n => n.toString())
-
-		ms.getMySavedTracks.mockImplementationOnce(async () =>
-			toTracks<SpotifyApi.SavedTrackObject>(savedTrackUris)
-		)
-		ms.addTracksToPlaylist
-			.mockImplementationOnce(async () => {
-				await new Promise(res => setTimeout(res, 200))
-				return { snapshot_id: 'snapshotId' }
-			})
-			.mockImplementationOnce(async () => ({ snapshot_id: 'snapshotId' }))
-		await sync.run({ scheduleTime })
-		const added = getUris(ms.addTracksToPlaylist.mock.calls)
-		expect(added.reverse()).toEqual(savedTrackUris)
-	})
-})
-
-describe(create.name, () => {
-	type Data<F> = F extends CallableFunction<infer T, unknown> ? T : never
-	const data: Data<typeof create> = { code: 'some_code', origin: 'http://localhost:5050' }
-	const rawRequest = {} as CallableRequest<unknown>['rawRequest']
-	type Auth = NonNullable<CallableRequest<unknown>['auth']>
-	const auth: Auth = {
-		uid: testEnv.auth.exampleUserRecord().uid,
-		token: {} as Auth['token']
-	}
+describe('create', () => {
+	const data: Data<typeof create> = { code: 'some_code', origin }
 
 	describe('new spotify account', () => {
 		test('creates new docuemnt', async () => {
@@ -75,7 +33,7 @@ describe(create.name, () => {
 
 	describe('no saved playlist id', () => {
 		beforeEach(async () => {
-			await doc.create({ refresh_token: 'userId' })
+			await doc.create({ refresh_token })
 		})
 
 		test('find old playlist', async () => {
@@ -98,51 +56,148 @@ describe(create.name, () => {
 		})
 	})
 
-	describe('throws error', () => {
-		describe('unauthorized (401)', () => {
-			test('unauthorized firebase user', async () => {
-				try {
-					await create.run({ data, rawRequest })
-					fail('An error should have been thrown.')
-				} catch (err) {
-					expect(err).toBeInstanceOf(HttpsError)
-					expect(err).toHaveProperty('code', 'unauthenticated')
-				}
-			})
-
-			test('bad spotify authorization', async () => {
-				ms.authorizationCodeGrant.mockRejectedValueOnce(
-					new Error('Invalid refresh token (invalid_grant)')
-				)
-				try {
-					await create.run({ data, auth, rawRequest })
-					fail('An error should have been thrown.')
-				} catch (err) {
-					expect(ms.authorizationCodeGrant).toBeCalledTimes(1)
-					expect(ms.getMe).not.toHaveBeenCalled()
-					expect(err).toBeInstanceOf(HttpsError)
-					expect(err).toHaveProperty('code', 'unauthenticated')
-				}
-			})
+	describe('unauthorized (401)', () => {
+		test('unauthorized firebase user', async () => {
+			try {
+				await create.run({ data, rawRequest })
+				fail('An error should have been thrown.')
+			} catch (err) {
+				expect(err).toBeInstanceOf(HttpsError)
+				expect(err).toHaveProperty('code', 'unauthenticated')
+			}
 		})
 
-		describe('not-found (404)', () => {
-			test('user unadded playlist', async () => {
-				ms.usersFollowPlaylist.mockImplementationOnce(async () => [false])
-				try {
-					await create.run({ data, auth, rawRequest })
-					fail('An error should have been thrown.')
-				} catch (err) {
-					expect(ms.getPlaylistTracks).not.toHaveBeenCalled()
-					expect(err).toBeInstanceOf(HttpsError)
-					expect(err).toHaveProperty('code', 'not-found')
-				}
-			})
+		test('bad spotify authorization', async () => {
+			ms.authorizationCodeGrant.mockRejectedValueOnce(
+				new Error('Invalid refresh token (invalid_grant)')
+			)
+			try {
+				await create.run({ data, auth, rawRequest })
+				fail('An error should have been thrown.')
+			} catch (err) {
+				expect(ms.authorizationCodeGrant).toBeCalledTimes(1)
+				expect(ms.getMe).not.toHaveBeenCalled()
+				expect(err).toBeInstanceOf(HttpsError)
+				expect(err).toHaveProperty('code', 'unauthenticated')
+			}
+		})
+	})
+
+	describe('not-found (404)', () => {
+		test('user unadded playlist', async () => {
+			ms.usersFollowPlaylist.mockImplementationOnce(async () => [false])
+			try {
+				await create.run({ data, auth, rawRequest })
+				fail('An error should have been thrown.')
+			} catch (err) {
+				expect(ms.getPlaylistTracks).not.toHaveBeenCalled()
+				expect(err).toBeInstanceOf(HttpsError)
+				expect(err).toHaveProperty('code', 'not-found')
+			}
 		})
 	})
 })
 
-describe(sync.name, () => {
+describe('populate', () => {
+	const data: Data<typeof populate> = { origin, userId: 'userId' }
+	describe('update playlist', () => {
+		beforeEach(async () => {
+			await doc.create({ playlist_id, refresh_token })
+		})
+		function toTracks<T>(uris: string[]): T[] {
+			return uris.map(uri => ({ track: { uri } } as T))
+		}
+		function getUris(calls: [string, string[]][]) {
+			return calls.flatMap(([, uris]) => uris)
+		}
+
+		test('update synced playlist', async () => {
+			const savedTrackUris = ['uri1', 'uri3', 'uri4', 'uri5']
+			const playlistTrackUris = ['uri2', 'uri4', 'uri6', 'uri7']
+			ms.getMySavedTracks.mockImplementationOnce(async () =>
+				toTracks<SpotifyApi.SavedTrackObject>(savedTrackUris)
+			)
+			ms.getPlaylistTracks.mockImplementationOnce(async () =>
+				toTracks<SpotifyApi.PlaylistTrackObject>(playlistTrackUris)
+			)
+			await sync.run({ scheduleTime })
+			const added = getUris(ms.addTracksToPlaylist.mock.calls)
+			const removed = getUris(ms.removeTracksToPlaylist.mock.calls)
+			expect(added.reverse()).toEqual(['uri1', 'uri3', 'uri5'])
+			expect(removed.sort()).toEqual(['uri2', 'uri6', 'uri7'])
+		})
+
+		test('Update are made in order', async () => {
+			const savedTrackUris = Array.from(Array(103).keys()).map(n => n.toString())
+
+			ms.getMySavedTracks.mockImplementationOnce(async () =>
+				toTracks<SpotifyApi.SavedTrackObject>(savedTrackUris)
+			)
+			ms.addTracksToPlaylist
+				.mockImplementationOnce(async () => {
+					await new Promise(res => setTimeout(res, 200))
+					return { snapshot_id: 'snapshotId' }
+				})
+				.mockImplementationOnce(async () => ({ snapshot_id: 'snapshotId' }))
+			await sync.run({ scheduleTime })
+			const added = getUris(ms.addTracksToPlaylist.mock.calls)
+			expect(added.reverse()).toEqual(savedTrackUris)
+		})
+	})
+
+	describe('unauthorized (401)', () => {
+		test('unauthorized firebase user', async () => {
+			try {
+				await populate.run({ data, rawRequest })
+				fail('An error should have been thrown.')
+			} catch (err) {
+				expect(err).toBeInstanceOf(HttpsError)
+				expect(err).toHaveProperty('code', 'unauthenticated')
+			}
+		})
+
+		test('bad spotify authorization', async () => {
+			await doc.create({ playlist_id, refresh_token })
+			ms.refreshAccessToken.mockRejectedValueOnce(
+				new Error('Invalid refresh token (invalid_grant)')
+			)
+			try {
+				await populate.run({ data, auth, rawRequest })
+				fail('An error should have been thrown.')
+			} catch (err) {
+				expect(ms.refreshAccessToken).toBeCalledTimes(1)
+				expect(ms.getMySavedTracks).not.toHaveBeenCalled()
+				expect(err).toBeInstanceOf(HttpsError)
+				expect(err).toHaveProperty('code', 'unauthenticated')
+			}
+		})
+	})
+
+	describe('not-found (404)', () => {
+		test('no document for user', async () => {
+			try {
+				await populate.run({ data, auth, rawRequest })
+				fail('An error should have been thrown.')
+			} catch (err) {
+				expect(err).toBeInstanceOf(HttpsError)
+				expect(err).toHaveProperty('code', 'not-found')
+			}
+		})
+
+		test('no playlist id for user', async () => {
+			await doc.create({ refresh_token })
+			try {
+				await populate.run({ data, auth, rawRequest })
+				fail('An error should have been thrown.')
+			} catch (err) {
+				expect(err).toBeInstanceOf(HttpsError)
+				expect(err).toHaveProperty('code', 'not-found')
+			}
+		})
+	})
+})
+
+describe('sync', () => {
 	describe('delete playlist', () => {
 		beforeEach(async () => {
 			await doc.create({ refresh_token: 'userId' })

--- a/src/app.css
+++ b/src/app.css
@@ -57,4 +57,18 @@
 	.btn-secondary:not(:disabled) {
 		@apply hover:bg-spotify-gray-600 hover:text-spotify-white;
 	}
+
+	.loading:after {
+		overflow: hidden;
+		display: inline-block;
+		vertical-align: bottom;
+		animation: ellipsis steps(4, end) 900ms infinite;
+		content: '\2026'; /* ascii code for the ellipsis character */
+		width: 0px;
+	}
+	@keyframes ellipsis {
+		to {
+			width: 1.25em;
+		}
+	}
 }

--- a/src/lib/firebase/functions.ts
+++ b/src/lib/firebase/functions.ts
@@ -8,4 +8,9 @@ if (dev) connectFunctionsEmulator(functions, 'localhost', 5001)
 export const createPublicLikedSongs = httpsCallable<{
 	code: string
 	origin: string
+}, { playlistId: string, userId: string }>(functions, 'publicLikedSongs-create')
+
+export const populatePublicLikedSongs = httpsCallable<{
+	userId: string
+	origin: string
 }>(functions, 'publicLikedSongs-create')

--- a/src/lib/firebase/functions.ts
+++ b/src/lib/firebase/functions.ts
@@ -1,16 +1,27 @@
 import { app } from '.'
 import { getFunctions, httpsCallable, connectFunctionsEmulator } from 'firebase/functions'
 import { dev } from '$app/environment'
+import type * as Tools from '@functions/tools'
 
 const functions = getFunctions(app)
 if (dev) connectFunctionsEmulator(functions, 'localhost', 5001)
 
-export const createPublicLikedSongs = httpsCallable<{
-	code: string
-	origin: string
-}, { playlistId: string, userId: string }>(functions, 'publicLikedSongs-create')
+type Tool = keyof typeof Tools
+type Method<T extends Tool> = keyof (typeof Tools)[T]
+type HttpsCallable<
+	T extends Tool,
+	M extends Method<T>
+> = (typeof Tools)[T][M] extends Tools.CallableFunction<infer A, infer R>
+	? ReturnType<typeof httpsCallable<A, Awaited<R>>>
+	: never
 
-export const populatePublicLikedSongs = httpsCallable<{
-	userId: string
-	origin: string
-}>(functions, 'publicLikedSongs-create')
+export const publicLikedSongs = {
+	create: httpsCallable(functions, 'publicLikedSongs-create') satisfies HttpsCallable<
+		'publicLikedSongs',
+		'create'
+	>,
+	populate: httpsCallable(functions, 'publicLikedSongs-populate') satisfies HttpsCallable<
+		'publicLikedSongs',
+		'populate'
+	>
+}

--- a/src/routes/(tools)/public-liked-songs/+page.svelte
+++ b/src/routes/(tools)/public-liked-songs/+page.svelte
@@ -8,7 +8,7 @@
 	import SpotifyEmbed from '$lib/components/spotify-embed.svelte'
 	import ErrorMsg from '$lib/components/ErrorMsg.svelte'
 
-	let createResponse: ReturnType<typeof publicLikedSongs['create']> | undefined
+	let createResponse: ReturnType<(typeof publicLikedSongs)['create']> | undefined
 	let isPopulated = false
 
 	onMount(() => {
@@ -22,7 +22,9 @@
 
 	async function createAndPopulate(code: string) {
 		createResponse = publicLikedSongs.create({ code, origin: location.origin })
-		const { data: { userId } } = await createResponse
+		const {
+			data: { userId }
+		} = await createResponse
 		await publicLikedSongs.populate({ userId, origin: location.origin })
 		isPopulated = true
 	}
@@ -33,17 +35,17 @@
 		{#await createResponse}
 			<Spinner />
 		{:then { data: { playlistId } }}
-				<SpotifyEmbed
-					title="public-liked-songs"
-					type="playlist"
-					id={playlistId}
-					className="mx-auto"
-				/>
-				{#if isPopulated}
-					<p>Playlist synced!</p>
-				{:else}
-					<p class='loading'>Populating playlist</p>
-				{/if}
+			<SpotifyEmbed
+				title="public-liked-songs"
+				type="playlist"
+				id={playlistId}
+				className="mx-auto"
+			/>
+			{#if isPopulated}
+				<p>Playlist synced!</p>
+			{:else}
+				<p class="loading">Populating playlist</p>
+			{/if}
 		{:catch error}
 			<ErrorMsg {error} />
 		{/await}

--- a/src/routes/(tools)/public-liked-songs/+page.svelte
+++ b/src/routes/(tools)/public-liked-songs/+page.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte'
-	import { createPublicLikedSongs, populatePublicLikedSongs } from '$lib/firebase/functions'
+	import { publicLikedSongs } from '$lib/firebase/functions'
 	import { user } from '$lib/stores'
 	import AuthorizeButton from '$lib/components/AuthorizeButton.svelte'
 	import LoginButton from '$lib/components/LoginButton.svelte'
@@ -8,7 +8,7 @@
 	import SpotifyEmbed from '$lib/components/spotify-embed.svelte'
 	import ErrorMsg from '$lib/components/ErrorMsg.svelte'
 
-	let createResponse: ReturnType<typeof createPublicLikedSongs> | undefined
+	let createResponse: ReturnType<typeof publicLikedSongs['create']> | undefined
 	let isPopulated = false
 
 	onMount(() => {
@@ -21,9 +21,9 @@
 	})
 
 	async function createAndPopulate(code: string) {
-		createResponse = createPublicLikedSongs({ code, origin: location.origin })
+		createResponse = publicLikedSongs.create({ code, origin: location.origin })
 		const { data: { userId } } = await createResponse
-		await populatePublicLikedSongs({ userId, origin: location.origin })
+		await publicLikedSongs.populate({ userId, origin: location.origin })
 		isPopulated = true
 	}
 </script>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,11 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
+		"strict": true,
+		"paths": {
+			"$lib": ["src/lib"],
+			"$lib/*": ["src/lib/*"],
+			"@functions/*": ["functions/src/*"]
+		},
 	}
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,6 +13,6 @@
 			"$lib": ["src/lib"],
 			"$lib/*": ["src/lib/*"],
 			"@functions/*": ["functions/src/*"]
-		},
+		}
 	}
 }


### PR DESCRIPTION
## Description

Splits the Firebase function `create` into two functions, `create` and `populate`.

They can be called one at a time, decreasing time to some sort of UI.

### Type of change

-   [x] Bug fix (#12)
-   [x] Build or configuration-related changes

## Checklist

-   [x] Commits are clear and use [gitmoji](https://github.com/carloscuesta/gitmoji).
-   [x] Lint my code locally.
-   [x] Added tests to cover changes.
-   [x] All new and existing tests passed.
