### PR TITLE
🐛 Use single line strings for playlist descriptions

### DIFF
--- a/functions/src/tools/public-liked-songs.ts
+++ b/functions/src/tools/public-liked-songs.ts
@@ -218,6 +218,8 @@ function name(userName = 'User') {
 	return userName + "'s Liked Songs"
 }
 function description() {
-	const date = new Date().toLocaleDateString('en-US')
-	return `Created at "https://spotify-tools/benkeys.com".\nLast updated on ${date}.`
+	const now = new Date()
+	const time = now.toLocaleTimeString('en-US')
+	const date = now.toLocaleDateString('en-US')
+	return `Created at "https://spotify-tools/benkeys.com". Last updated on ${time} ${date}.`
 }


### PR DESCRIPTION
## Description

Changes playlist descriptions to a single-line string. For some reason, a line break is causing the API endpoint to return an error.

### Type of change

Bug fix (#31)

## Checklist

-   [x] Commits are clear and use [gitmoji](https://github.com/carloscuesta/gitmoji).
-   [x] Lint my code locally.
-   [x] Updated the documentation accordingly.
-   [x] Added tests to cover changes.
-   [x] All new and existing tests passed.
